### PR TITLE
Add better command permissions using SimplePermissions

### DIFF
--- a/GCBot/GCBot.Container/Program.cs
+++ b/GCBot/GCBot.Container/Program.cs
@@ -33,7 +33,7 @@ namespace GCBot.Container
             ServiceCollection serviceCollection = new ServiceCollection();
 
             serviceCollection.AddSingleton(typeof(IConfigurationRoot), config);
-            
+
             serviceCollection.AddSingleton<IBackupService, BackupService>()
                 .AddSingleton<IBackupRepository, BackupRepository>()
                 .AddSingleton(new BackupContext(""));

--- a/GCBot/GCBot.Infrastructure/BotConfiguration/GcBotConfig.cs
+++ b/GCBot/GCBot.Infrastructure/BotConfiguration/GcBotConfig.cs
@@ -1,0 +1,19 @@
+using Discord.Addons.SimplePermissions;
+using Microsoft.EntityFrameworkCore;
+
+namespace GCBot.Infrastructure.BotConfiguration
+{
+    public sealed class GcUser : ConfigUser {}
+    public sealed class GcChannel : ConfigChannel<GcUser> {}
+
+    public sealed class GcGuild : ConfigGuild<GcChannel, GcUser>
+    {
+        public char CommandPrefix { get; set; } = Client.DefaultCommandPrefix;
+    }
+    public sealed class GcBotConfig : EFBaseConfigContext<GcGuild, GcChannel, GcUser>
+    {
+        public GcBotConfig(DbContextOptions options) : base(options)
+        {
+        }
+    }
+}

--- a/GCBot/GCBot.Infrastructure/Client.cs
+++ b/GCBot/GCBot.Infrastructure/Client.cs
@@ -1,9 +1,14 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using Discord;
+using Discord.Addons.SimplePermissions;
 using Discord.Commands;
 using Discord.WebSocket;
+using GCBot.Infrastructure.BotConfiguration;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -12,29 +17,41 @@ namespace GCBot.Infrastructure
 {
     public class Client
     {
+        public const char DefaultCommandPrefix = '$';
+
         public IServiceProvider Services { get; }
         public DiscordSocketClient SocketClient;
 
-        private IConfigurationRoot _configuration;
-        
+        private readonly IConfigStore<GcBotConfig> _botConfigStore;
+        private readonly IConfigurationRoot _applicationConfiguration;
+
         // locals
         private readonly CommandService _commands = new CommandService();
-        public Client(ServiceCollection serviceDescriptors, IConfigurationRoot configuration)
+
+        public Client(ServiceCollection serviceDescriptors, IConfigurationRoot applicationConfiguration)
         {
             if (serviceDescriptors == null) serviceDescriptors = new ServiceCollection();
-            _configuration = configuration;
+            _applicationConfiguration = applicationConfiguration;
             
-            if (!Enum.TryParse(_configuration["Logging:LogLevel:Default"], out LogSeverity logLevel))
+            if (!Enum.TryParse(_applicationConfiguration["Logging:LogLevel:Default"], out LogSeverity logLevel))
             {
                 logLevel = LogSeverity.Info;
             }
+
+            _botConfigStore = new EFConfigStore<GcBotConfig, GcGuild, GcChannel, GcUser>(_commands, Log);
             
             SocketClient = new DiscordSocketClient(new DiscordSocketConfig{LogLevel = logLevel});
 
             Services = serviceDescriptors
                 .AddSingleton(SocketClient)
                 .AddSingleton(_commands)
+                .AddSingleton(new PermissionsService(_botConfigStore, _commands, SocketClient, Log))
+                .AddSingleton(_botConfigStore)
+                .AddDbContext<GcBotConfig>(options => options.UseMySql(_applicationConfiguration.GetConnectionString("Database")))
                 .BuildServiceProvider();
+
+            Services.GetService<GcBotConfig>().Database.EnsureCreated();
+            ((EFConfigStore<GcBotConfig, GcGuild, GcChannel, GcUser>) _botConfigStore).Services = Services;
         }
 
         /// <summary>
@@ -47,7 +64,7 @@ namespace GCBot.Infrastructure
                 SocketClient.Log += Log;
                 await RegisterCommandsAsync();
 
-                await SocketClient.LoginAsync(Discord.TokenType.Bot, _configuration["token"]);
+                await SocketClient.LoginAsync(Discord.TokenType.Bot, _applicationConfiguration["token"]);
                 await SocketClient.StartAsync();
 
                 await Task.Delay(-1);
@@ -61,6 +78,7 @@ namespace GCBot.Infrastructure
         private async Task RegisterCommandsAsync()
         {
             SocketClient.MessageReceived += HandleCommandAsync;
+            await _commands.AddModuleAsync<PermissionsModule>(Services);
             await _commands.AddModulesAsync(GetType().Assembly, Services);
         }
 
@@ -71,14 +89,30 @@ namespace GCBot.Infrastructure
 
             if (msg is null) return;
 
-
-            if (!msg.Author.IsBot && msg.HasCharPrefix('$', ref argPos))
+            using (GcBotConfig config = _botConfigStore.Load())
             {
-                var context = new SocketCommandContext(SocketClient, msg);
-                var result = await _commands.ExecuteAsync(context, argPos, Services);
-             
-                if (!result.IsSuccess) return;
+                SocketGuildUser user = msg.Author as SocketGuildUser;
+
+                char commandPrefix = DefaultCommandPrefix;
+
+                if (user != null && config != null)
+                {
+                    GcGuild guild = config.Guilds.FirstOrDefault(g => g.GuildId == user.Guild.Id);
+                    if (guild != null)
+                    {
+                        commandPrefix = guild.CommandPrefix;
+                    }
+                }
+                
+                if (!msg.Author.IsBot && msg.HasCharPrefix(commandPrefix, ref argPos))
+                {
+                    var context = new SocketCommandContext(SocketClient, msg);
+                    var result = await _commands.ExecuteAsync(context, argPos, Services);
+                 
+                    if (!result.IsSuccess) return;
+                }
             }
+
         }
 
         private Task Log(LogMessage arg)

--- a/GCBot/GCBot.Infrastructure/GCBot.Infrastructure.csproj
+++ b/GCBot/GCBot.Infrastructure/GCBot.Infrastructure.csproj
@@ -8,9 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Discord.Addons.SimplePermissions" Version="1.2.0-alpha2" />
+    <PackageReference Include="Discord.Addons.SimplePermissions.EFProvider" Version="1.2.0-alpha2" />
     <PackageReference Include="Discord.Net" Version="2.1.1" />
+    <PackageReference Include="Discord.Net.Commands" Version="2.1.1" />
+    <PackageReference Include="Discord.Net.WebSocket" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GCBot/GCBot.Infrastructure/Modules/ConfigModule.cs
+++ b/GCBot/GCBot.Infrastructure/Modules/ConfigModule.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord.Addons.SimplePermissions;
+using Discord.Commands;
+using Discord.WebSocket;
+using GCBot.Infrastructure.BotConfiguration;
+
+namespace GCBot.Infrastructure.Modules
+{
+    public class ConfigModule : ModuleBase
+    {
+        private readonly IConfigStore<GcBotConfig> _configStore;
+
+        public ConfigModule(IConfigStore<GcBotConfig> configStore)
+        {
+            _configStore = configStore;
+        }
+        
+        [Command("SetPrefix")]
+        [Permission(MinimumPermission.AdminRole)]
+        public async Task SetPrefix(char prefix)
+        {
+            if (char.IsLetterOrDigit(prefix) || char.IsWhiteSpace(prefix))
+            {
+                await ReplyAsync(
+                    $"`{prefix}` is not a valid command prefix. " +
+                    $"Letters, numbers, and whitespaces are not acceptable as a command prefix.");
+                return;
+            };
+            
+            using (GcBotConfig config = _configStore.Load())
+            {
+                GcGuild guild = config.Guilds.FirstOrDefault(g => g.GuildId == Context.Guild.Id);
+                if (guild == null) return;
+
+                guild.CommandPrefix = prefix;
+                config.Save();
+
+                await ReplyAsync($"Updated the bot command prefix to {prefix}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This feature utilizes [Simple Permissions Addon](https://github.com/Joe4evr/Discord.Addons/tree/master/src/Discord.Addons.SimplePermissions) and closes #11. 
This adds the ability to specify permission groups for commands. This gives better control to specifying which commands or modules should be executed by which groups.

The permission groups inherit from the groups below it:
- Guild Owner
- Admin Role
- Mod Role
- Everyone

The following permission groups are not inherited:
- Special
- Bot Owner

Each channel can have different modules whitelisted or blacklisted using the `whitelist` and `blacklist` commands. Alternatively, use `whitelist <module> g` to whitelist the module in all channels. Modules are blacklisted by default. 

The special role can be added to users (__not roles__) using `addspecial` command and removed using `remspecial` command.

To set the admin or mod roles: `setmod <role id>` `setadmin <role id>`

> Note:  the addon only allows one mod role and one admin role. May change implementation to allow multiple in future.